### PR TITLE
reformat demo() output

### DIFF
--- a/nltk/metrics/aline.py
+++ b/nltk/metrics/aline.py
@@ -516,7 +516,10 @@ def demo():
     """
     data = [pair.split(',') for pair in cognate_data.split('\n')]
     for pair in data:
-        print(pair[0], "~", pair[1], ":", align(pair[0], pair[1])[0])
+        alignment = align(pair[0], pair[1])[0]
+        alignment = ['({}, {})'.format(a[0], a[1]) for a in alignment]
+        alignment = ' '.join(alignment)
+        print('{} ~ {} : {}'.format(pair[0], pair[1], alignment))
 
 cognate_data = """jo,ʒə
 tu,ty


### PR DESCRIPTION
Hi fievelk,

I've reformatted output of demo() in aline.py, because with the new unicode support in python2.7, the output was a little overwhelming for the user. What do you think?
