### PR TITLE
Make tox aware of environment variables

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -7,6 +7,9 @@ setenv =
     LAPACK=
     ATLAS=None
 
+; Copy all environment variables to the tox test environment
+passenv = *
+
 deps =
     numpy
     nose >= 1.2.1


### PR DESCRIPTION
For example, this fix allows tox to find NLTK data when a custom NLTK_DATA environment variable is set